### PR TITLE
var使用错误

### DIFF
--- a/bilibili_bangumi_area_limit_hack.user.js
+++ b/bilibili_bangumi_area_limit_hack.user.js
@@ -645,8 +645,8 @@ function scriptSource(invokeBy) {
     }
     const util_generate_sign = function (params, key) {
         var s_keys = [];
-        for (var i in params) {
-            s_keys.push(i);
+        for (var j in params) {
+            s_keys.push(j);
         }
         s_keys.sort();
         var data = "";


### PR DESCRIPTION
ES6 之前的JavaScript没用块级作用域，648行这里定义了变量i,653行的循环体中又一次定义了变量i,两者指向同一对象，造成语法错误