### PR TITLE
在用户自定义代理服务器下，解除仅限客户端播放限制（使用客户端接口）

### DIFF
--- a/scripts/bilibili_bangumi_area_limit_hack.user.js
+++ b/scripts/bilibili_bangumi_area_limit_hack.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         解除B站区域限制
 // @namespace    http://tampermonkey.net/
-// @version      8.0.4
+// @version      8.0.5
 // @description  通过替换获取视频地址接口的方式, 实现解除B站区域限制; 只对HTML5播放器生效;
 // @author       ipcjs
 // @supportURL   https://github.com/ipcjs/bilibili-helper/blob/user.js/packages/unblock-area-limit/README.md
@@ -2588,6 +2588,49 @@ function scriptSource(invokeBy) {
             function isAreaLimitForPlayUrl(json) {
                 return (json.errorcid && json.errorcid == '8986943') || (json.durl && json.durl.length === 1 && json.durl[0].length === 15126 && json.durl[0].size === 124627);
             }
+			
+			// 构建 mobi api 解析链接
+			// host 举例: 'https://example.com'
+			function getMobiPlayUrl(originUrl, host){
+				// 提取参数为数组
+				let a = originUrl.split('?')[1].split('&');
+				// 参数数组转换为对象
+				let theRequest = new Object();
+				for (let i = 0; i < a.length; i++) {
+					let key = a[i].split("=")[0];
+					let value = a[i].split("=")[1];
+					// 给对象赋值
+					theRequest[key] = value;
+				}
+				// 追加 mobi api 需要的参数
+				theRequest.access_key = localStorage.access_key;
+				theRequest.appkey = '07da50c9a0bf829f';
+				theRequest.build = '5380700';
+				theRequest.buvid = 'XY418E94B89774E201E22C5B709861B7712DD';
+				theRequest.device = 'android';
+				theRequest.force_host = '2';
+				theRequest.mobi_app = 'android_b';
+				theRequest.platform = 'android_b';
+				theRequest.track_path = '0';
+				theRequest.device = 'android';
+				theRequest.fnval = '0'; // 强制 FLV
+				theRequest.ts = Date.parse(new Date())/1000;
+				// 所需参数数组
+				let param_wanted = ['access_key','appkey','build','buvid','cid','device','ep_id','fnval','fnver','force_host','fourk','mobi_app','platform','qn','track_path','ts'];
+				// 生成 mobi api 参数字符串
+				let mobi_api_params = '';
+				for (let i = 0; i < param_wanted.length; i++){
+					mobi_api_params += param_wanted[i] + `=` + theRequest[param_wanted[i]] + `&`;
+				}
+				// 准备明文
+				let plaintext = mobi_api_params.slice(0,-1) + `25bdede4e1581c836cab73a48790ca6e`;
+				// 生成 sign
+				let ciphertext = hex_md5(plaintext);
+				// 合成完整 mobi api url
+				let mobi_api_url = `${host}/pgc/player/api/playurl?` + mobi_api_params + `sign=` + ciphertext;
+
+				return mobi_api_url;
+			}
 
             var bilibiliApis = (function () {
                 function AjaxException(message, code = 0/*用0表示未知错误*/) {
@@ -2851,12 +2894,20 @@ function scriptSource(invokeBy) {
                             .then(r => this.processProxySuccess(r))
                     },
                     transToProxyUrl: function (originUrl, proxyHost) {
+						if (window.__balh_app_only__){
+							// APP 限定用 mobi api
+							return getMobiPlayUrl(originUrl, proxyHost);
+						}
                         return originUrl.replace(/^(https:)?(\/\/api\.bilibili\.com\/)/, `$1${proxyHost}/`) + access_key_param_if_exist(true);
                     },
                     processProxySuccess: function (result) {
                         if (result.code) {
                             return Promise$1.reject(result)
                         }
+						// 在APP限定情况启用 mobi api 解析
+						if (window.__balh_app_only__){
+							return result;
+						}
                         return result.result
                     },
                 });

--- a/scripts/bilibili_bangumi_area_limit_hack.user.js
+++ b/scripts/bilibili_bangumi_area_limit_hack.user.js
@@ -2589,48 +2589,48 @@ function scriptSource(invokeBy) {
                 return (json.errorcid && json.errorcid == '8986943') || (json.durl && json.durl.length === 1 && json.durl[0].length === 15126 && json.durl[0].size === 124627);
             }
 			
-			// 构建 mobi api 解析链接
-			// host 举例: 'https://example.com'
-			function getMobiPlayUrl(originUrl, host){
-				// 提取参数为数组
-				let a = originUrl.split('?')[1].split('&');
-				// 参数数组转换为对象
-				let theRequest = new Object();
-				for (let i = 0; i < a.length; i++) {
-					let key = a[i].split("=")[0];
-					let value = a[i].split("=")[1];
-					// 给对象赋值
-					theRequest[key] = value;
-				}
-				// 追加 mobi api 需要的参数
-				theRequest.access_key = localStorage.access_key;
-				theRequest.appkey = '07da50c9a0bf829f';
-				theRequest.build = '5380700';
-				theRequest.buvid = 'XY418E94B89774E201E22C5B709861B7712DD';
-				theRequest.device = 'android';
-				theRequest.force_host = '2';
-				theRequest.mobi_app = 'android_b';
-				theRequest.platform = 'android_b';
-				theRequest.track_path = '0';
-				theRequest.device = 'android';
-				theRequest.fnval = '0'; // 强制 FLV
-				theRequest.ts = Date.parse(new Date())/1000;
-				// 所需参数数组
-				let param_wanted = ['access_key','appkey','build','buvid','cid','device','ep_id','fnval','fnver','force_host','fourk','mobi_app','platform','qn','track_path','ts'];
-				// 生成 mobi api 参数字符串
-				let mobi_api_params = '';
-				for (let i = 0; i < param_wanted.length; i++){
-					mobi_api_params += param_wanted[i] + `=` + theRequest[param_wanted[i]] + `&`;
-				}
-				// 准备明文
-				let plaintext = mobi_api_params.slice(0,-1) + `25bdede4e1581c836cab73a48790ca6e`;
-				// 生成 sign
-				let ciphertext = hex_md5(plaintext);
-				// 合成完整 mobi api url
-				let mobi_api_url = `${host}/pgc/player/api/playurl?` + mobi_api_params + `sign=` + ciphertext;
+            // 构建 mobi api 解析链接
+            // host 举例: 'https://example.com'
+            function getMobiPlayUrl(originUrl, host){
+                // 提取参数为数组
+                let a = originUrl.split('?')[1].split('&');
+                // 参数数组转换为对象
+                let theRequest = new Object();
+                for (let i = 0; i < a.length; i++) {
+                    let key = a[i].split("=")[0];
+                    let value = a[i].split("=")[1];
+                    // 给对象赋值
+                    theRequest[key] = value;
+                }
+                // 追加 mobi api 需要的参数
+                theRequest.access_key = localStorage.access_key;
+                theRequest.appkey = '07da50c9a0bf829f';
+                theRequest.build = '5380700';
+                theRequest.buvid = 'XY418E94B89774E201E22C5B709861B7712DD';
+                theRequest.device = 'android';
+                theRequest.force_host = '2';
+                theRequest.mobi_app = 'android_b';
+                theRequest.platform = 'android_b';
+                theRequest.track_path = '0';
+                theRequest.device = 'android';
+                theRequest.fnval = '0'; // 强制 FLV
+                theRequest.ts = Date.parse(new Date())/1000;
+                // 所需参数数组
+                let param_wanted = ['access_key','appkey','build','buvid','cid','device','ep_id','fnval','fnver','force_host','fourk','mobi_app','platform','qn','track_path','ts'];
+                // 生成 mobi api 参数字符串
+                let mobi_api_params = '';
+                for (let i = 0; i < param_wanted.length; i++){
+                    mobi_api_params += param_wanted[i] + `=` + theRequest[param_wanted[i]] + `&`;
+                }
+                // 准备明文
+                let plaintext = mobi_api_params.slice(0,-1) + `25bdede4e1581c836cab73a48790ca6e`;
+                // 生成 sign
+                let ciphertext = hex_md5(plaintext);
+                // 合成完整 mobi api url
+                let mobi_api_url = `${host}/pgc/player/api/playurl?` + mobi_api_params + `sign=` + ciphertext;
 
-				return mobi_api_url;
-			}
+                return mobi_api_url;
+            }
 
             var bilibiliApis = (function () {
                 function AjaxException(message, code = 0/*用0表示未知错误*/) {
@@ -2894,20 +2894,20 @@ function scriptSource(invokeBy) {
                             .then(r => this.processProxySuccess(r))
                     },
                     transToProxyUrl: function (originUrl, proxyHost) {
-						if (window.__balh_app_only__){
-							// APP 限定用 mobi api
-							return getMobiPlayUrl(originUrl, proxyHost);
-						}
+                        if (window.__balh_app_only__){
+                            // APP 限定用 mobi api
+                            return getMobiPlayUrl(originUrl, proxyHost);
+                        }
                         return originUrl.replace(/^(https:)?(\/\/api\.bilibili\.com\/)/, `$1${proxyHost}/`) + access_key_param_if_exist(true);
                     },
                     processProxySuccess: function (result) {
                         if (result.code) {
                             return Promise$1.reject(result)
                         }
-						// 在APP限定情况启用 mobi api 解析
-						if (window.__balh_app_only__){
-							return result;
-						}
+                        // 在APP限定情况启用 mobi api 解析
+                        if (window.__balh_app_only__){
+                            return result;
+                        }
                         return result.result
                     },
                 });


### PR DESCRIPTION
**该方法由 @yujincheng08 提供。**
相关issue：https://github.com/kghost/bilibili-area-limit/issues/16

只对限定客户端的番剧生效，非限定还是用的 Web 解析。
**需要能够取得 akamaized 的节点进行解析（香港谷歌云测试可以）**
测试番剧 ：https://www.bilibili.com/bangumi/play/ep359330

另外，在 2616 行的 ```theRequest.fnval = '0'; // 强制 FLV``` 这行注释掉可以取得 DASH，但是无法播放，不知道什么原因，希望大佬可以帮忙看看

PS：解析出来的视频地址（FLV+DASH）可以将 akam 给换成国内 upos，要求客户端UA（```Bilibili Freedoooooom/MarkII```），用 GM.xmlHttpRequest 应该能做，大佬有没有想法写写？

## Nginx反代配置
```nginx
server
{
    server_name example.com 
    
    listen 443 ssl http2;
    listen [::]:443 ssl http2;

    client_max_body_size 128M;

    location /pgc/player/api/playurl { 
		proxy_pass https://api.bilibili.com;
    }

    location /pgc/player/web/playurl {
		proxy_pass https://api.bilibili.com;
    }

    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem; # managed by Certbot
    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem; # managed by Certbot
    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
}
```

## 泰区Nginx反代配置
 - 包含视频解析、字幕、番剧数据、番剧搜索、番剧索引接口
 - 目前部分接口没有被脚本或漫游所使用
```nginx
server {
        server_name example.com
        client_max_body_size 128M;

        location /intl/gateway/v2/ogv/playurl {
                proxy_pass https://api.global.bilibili.com;
        }

        location /intl/gateway/v2/app/subtitle {
                proxy_pass https://app.global.bilibili.com;
        }

        location /intl/gateway/v2/app/search {
                proxy_pass https://app.global.bilibili.com;
        }

        location /intl/gateway/v2/ogv/season/index/result {
                proxy_pass https://api.global.bilibili.com;
        }

        location /intl/gateway/ogv/m/view {
                proxy_pass https://api.global.bilibili.com;
        }

        location /intl/gateway/ogv/view/app/subtitle {
                proxy_pass https://api.global.bilibili.com;
        }

        location /intl/gateway/v2/ogv/view/app/season {
                proxy_pass https://api.global.bilibili.com;
        }


    listen 443 ssl; # managed by Certbot
    ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem; # managed by Certbot
    ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem; # managed by Certbot
    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
}
```

如果反代想配合代理使用，请参见 [《配置 Nginx 通过代理访问反代目标》](https://gist.github.com/miyouzi/3e3d57cde402b829aeb1d865b14eaa1a)