### PR TITLE
修改自定义服务器正则

### DIFF
--- a/scripts/bilibili_bangumi_area_limit_hack.user.js
+++ b/scripts/bilibili_bangumi_area_limit_hack.user.js
@@ -179,7 +179,7 @@ function scriptSource(invokeBy) {
             FALSE: FALSE,
         },
         regex: {
-            custom_server: /^https?:\/\/[\w-_.]+$/,
+            custom_server: /^https?:\/\/[\w-_.\/]+$/,
         },
         baipiao: [
             { key: 'zomble_land_saga', match: () => { var _a, _b; return ((_b = (_a = window.__INITIAL_STATE__) === null || _a === void 0 ? void 0 : _a.epInfo) === null || _b === void 0 ? void 0 : _b.ep_id) === 251255; }, link: 'http://www.acfun.cn/bangumi/ab5022161_31405_278830', message: r_text.welcome_to_acfun },


### PR DESCRIPTION
腾讯云请求 API 网关需要在域名后添加 /release/函数名
原来的正则匹配 腾讯云函数 / 任意带路径的地址 时会在填入的自定义服务器地址后直接添加参数，导致反代无法正常工作

应请求的地址 https://xxxxxxx.gz.apigw.tencentcs.com/release/函数名/pgc/player/web/playurl?avid=...后略
目前请求的地址 https://xxxxxxx.gz.apigw.tencentcs.com/release/函数名?avid=...后略