### PR TITLE
支持APP源DASH播放

### DIFF
--- a/packages/unblock-area-limit/src/api/biliplus.ts
+++ b/packages/unblock-area-limit/src/api/biliplus.ts
@@ -62,7 +62,7 @@ export function generateMobiPlayUrlParams(originUrl: String) {
     theRequest.platform = 'android_b';
     theRequest.track_path = '0';
     theRequest.device = 'android';
-    // theRequest.fnval = '0'; // 强制 FLV
+    theRequest.fnval = '0'; // 强制 FLV
     theRequest.ts = `${~~(Date.now() / 1000)}`;
     // 所需参数数组
     let param_wanted = ['access_key', 'appkey', 'build', 'buvid', 'cid', 'device', 'ep_id', 'fnval', 'fnver', 'force_host', 'fourk', 'mobi_app', 'platform', 'qn', 'track_path', 'ts'];

--- a/packages/unblock-area-limit/src/api/biliplus.ts
+++ b/packages/unblock-area-limit/src/api/biliplus.ts
@@ -82,6 +82,13 @@ export function fixMobiPlayUrlJson(originJson: object) {
     interface PlayUrlResult {
         type: string
         timelength: number
+        accept_description: string[]
+        accept_quality: number[]
+        support_formats: [{
+            quality: number
+            need_login?: boolean
+        }]
+        format: string
         dash: {
             duration: number
             minBufferTime: number
@@ -127,6 +134,7 @@ export function fixMobiPlayUrlJson(originJson: object) {
     }
     const codecsMap: StringStringObject = {
         30112: 'avc1.640028',  // 1080P+
+        30102: 'hev1.1.6.L120.90',  // HEVC 1080P+
         30080: 'avc1.640028',  // 1080P
         30077: 'hev1.1.6.L120.90',  // HEVC 1080P
         30064: 'avc1.64001F',  // 720P
@@ -137,10 +145,18 @@ export function fixMobiPlayUrlJson(originJson: object) {
         30016: 'avc1.64001E',  // 360P
         30280: 'mp4a.40.2',  // 高码音频
         30232: 'mp4a.40.2',  // 中码音频
-        30216: 'mp4a.40.2'  // 低码音频
+        30216: 'mp4a.40.2',  // 低码音频
+        'nb2-1-30016': 'avc1.64001E',  // APP源 360P
+        'nb2-1-30032': 'avc1.64001F',  // APP源 480P
+        'nb2-1-30064': 'avc1.640028',  // APP源 720P
+        'nb2-1-30080': 'avc1.640032',  // APP源 1080P
+        'nb2-1-30216': 'mp4a.40.2',  // APP源 低码音频
+        'nb2-1-30232': 'mp4a.40.2',  // APP源 中码音频
+        'nb2-1-30280': 'mp4a.40.2'  // APP源 高码音频
     }
     const resolutionMap: { [k: string]: [w: number, h: number] } = {
         30112: [1920, 1080],  // 1080P+
+        30102: [1920, 1080],  // HEVC 1080P+
         30080: [1920, 1080],  // 1080P
         30077: [1920, 1080],  // HEVC 1080P
         30064: [1280, 720],  // 720P
@@ -150,16 +166,62 @@ export function fixMobiPlayUrlJson(originJson: object) {
         30011: [640, 360],  // HEVC 360P
         30016: [640, 360],  // 360P
     }
+    const frameRateMap: StringStringObject = {
+        30112: '16000/672',
+        30102: '16000/672',
+        30080: '16000/672',
+        30077: '16000/656',
+        30064: '16000/672',
+        30066: '16000/656',
+        30032: '16000/672',
+        30033: '16000/656',
+        30011: '16000/656',
+        30016: '16000/672'
+    }
 
-    let result: PlayUrlResult = JSON.parse(JSON.stringify(originJson));
+    function getSegmentBase(url: string, id: string): [string, string] {
+        // 从 window 中读取已有的值
+        if (window.__segment_base_map__) {
+            if (window.__segment_base_map__.hasOwnProperty(id)) {
+                // console.log('SegmentBase read from cache ', window.__segment_base_map__[id])
+                return window.__segment_base_map__[id]
+            }
+        }
 
-    result.dash.duration = Math.round(result.timelength / 1000)
+        // 同步模式下 xhr 无法设置 responseType  https://stackoverflow.com/questions/9855127/setting-xmlhttprequest-responsetype-forbidden-all-of-a-sudden
+        let xhr = new XMLHttpRequest();
+        xhr.overrideMimeType('text/plain; charset=x-user-defined');
+        xhr.open('GET', url, false)  // 同步模式
+        xhr.setRequestHeader('Range', 'bytes=0-6000')  // 下载前 6000 字节数据用于查找 sidx 位置
+        xhr.send(null)  // 发送请求
+        // 数据读取为 arraybuffer
+        let data = Uint8Array.from(xhr.response, c => c.charCodeAt(0));  // 不用管这句红蚯蚓
+        // 转换成 hex
+        let hex_data = Array.prototype.map.call(data, x => ('00' + x.toString(16)).slice(-2)).join('')
+        let indexRangeStart = hex_data.indexOf('73696478') / 2 - 4  // 73696478 是 'sidx' 的 hex ，前面还有 4 个字节才是 sidx 的开始
+        let indexRagneEnd = hex_data.indexOf('6d6f6f66') / 2 - 5  // 6d6f6f66 是 'moof' 的 hex，前面还有 4 个字节才是 moof 的开始，-1为sidx结束位置
+        let result: [string, string] = ['0-' + String(indexRangeStart - 1), String(indexRangeStart) + '-' + String(indexRagneEnd)]
+
+        // 储存在 window，切换清晰度不用重新解析
+        if (window.__segment_base_map__) {
+            window.__segment_base_map__[id] = result
+        } else {
+            window.__segment_base_map__ = {}
+            window.__segment_base_map__[id] = result
+        }
+        // console.log('get SegmentBase', result)
+        return result
+    }
+
+    let result: PlayUrlResult = JSON.parse(JSON.stringify(originJson))
+
+    result.dash.duration = Math.round(result.timelength / 1000) + 1  // 最后result数据会很奇怪的 -1，所以 +1 补上
     result.dash.minBufferTime = 1.5
     result.dash.min_buffer_time = 1.5
 
     // 填充视频流数据
     result.dash.video.forEach((video) => {
-        let i = /\d{5}\.m4s/.exec(video.baseUrl)
+        let i = /(nb2-1-)?\d{5}\.m4s/.exec(video.baseUrl)
         let video_id: string
         if (i !== null) {
             video_id = i[0].replace('.m4s', '')
@@ -167,24 +229,27 @@ export function fixMobiPlayUrlJson(originJson: object) {
             video_id = '30080'
         }
 
-        // let video_id: string = /\d{5}\.m4s/.exec(video.baseUrl)?[0] ?? '30080' ;
         video.codecs = codecsMap[video_id]
+        video_id = video_id.replace('nb2-1-', '')
+
         video.width = resolutionMap[video_id][0]
         video.height = resolutionMap[video_id][1]
         video.mimeType = 'video/mp4'
         video.mime_type = 'video/mp4'
-        video.frameRate = '16000/672'
-        video.frame_rate = '16000/672'
+        video.frameRate = frameRateMap[video_id]
+        video.frame_rate = frameRateMap[video_id]
         video.sar = "1:1"
         video.startWithSAP = 1
         video.start_with_sap = 1
+
+        let segmentBase = getSegmentBase(video.baseUrl, video_id)
         video.segment_base = {
-            initialization: "0-973",
-            index_range: "974-4485"
+            initialization: segmentBase[0],
+            index_range: segmentBase[1]
         }
         video.SegmentBase = {
-            Initialization: "0-973",
-            indexRange: "974-4485"
+            Initialization: segmentBase[0],
+            indexRange: segmentBase[1]
         }
     });
 
@@ -200,15 +265,18 @@ export function fixMobiPlayUrlJson(originJson: object) {
         audio.codecs = codecsMap[audio_id]
         audio.mimeType = 'audio/mp4'
         audio.mime_type = 'audio/mp4'
+
+        let segmentBase = getSegmentBase(audio.baseUrl, audio_id)
         audio.segment_base = {
-            initialization: "0-973",
-            index_range: "974-4485"
+            initialization: segmentBase[0],
+            index_range: segmentBase[1]
         }
         audio.SegmentBase = {
-            Initialization: "0-973",
-            indexRange: "974-4485"
+            Initialization: segmentBase[0],
+            indexRange: segmentBase[1]
         }
     });
+
     return result
 }
 

--- a/packages/unblock-area-limit/src/dts/global.ts
+++ b/packages/unblock-area-limit/src/dts/global.ts
@@ -16,6 +16,7 @@ declare global {
             new(): BiliMessageBox
             prototype: BiliMessageBox
         }
+        __segment_base_map__?: { [k: string]: [initialization: string, indexRange: string] }
     }
     interface Promise<T> {
         compose: any

--- a/packages/unblock-area-limit/src/main.dev.user.js
+++ b/packages/unblock-area-limit/src/main.dev.user.js
@@ -19,6 +19,7 @@
 // @include      *://www.bilibili.com/bangumi/media/md*
 // @include      *://www.bilibili.com/blackboard/html5player.html*
 // @include      *://link.acg.tv/forum.php*
+// @include      https://www.mcbbs.net/template/mcbbs/image/special_photo_bg.png*
 // @run-at       document-start
 // @grant        none
 // @require      file:///C:/GitHub/bilibili-helper/scripts/bilibili_bangumi_area_limit_hack.user.js

--- a/packages/unblock-area-limit/src/main.js
+++ b/packages/unblock-area-limit/src/main.js
@@ -9,7 +9,7 @@ import { balh_config, isClosed } from './feature/config'
 import { Func } from './util/utils';
 import { util_page } from './feature/page'
 import { access_key_param_if_exist, platform_android_param_if_app_only } from './api/bilibili';
-import { BiliPlusApi, generateMobiPlayUrlParams, getMobiPlayUrl } from './api/biliplus';
+import { BiliPlusApi, generateMobiPlayUrlParams, getMobiPlayUrl, fixMobiPlayUrlJson } from './api/biliplus';
 import { ui } from './util/ui'
 import { Strings } from './util/strings'
 import { util_init } from './util/initiator'
@@ -147,9 +147,9 @@ function scriptContent() {
                                                     if (!data.code && data.data.subtitle) {
                                                         // 使用APP接口获取的字幕信息重构返回数据，其它成员不明暂时无视
                                                         const subtitle = data.data.subtitle;
-                                                        subtitle.subtitles.forEach(item=>(item.subtitle_url = item.subtitle_url.replace(/https?:\/\//,'//')));
+                                                        subtitle.subtitles.forEach(item => (item.subtitle_url = item.subtitle_url.replace(/https?:\/\//, '//')));
                                                         subtitle.allow_submit = false;
-                                                        json.data = {subtitle};
+                                                        json.data = { subtitle };
                                                         json.code = 0;
                                                         if (balh_config.blocked_vip) {
                                                             json.data.vip = {
@@ -871,6 +871,12 @@ function scriptContent() {
                     }
                     // 在APP限定情况启用 mobi api 解析
                     if (window.__balh_app_only__) {
+                        if (result['type'] == "DASH") {
+                            let i = fixMobiPlayUrlJson(result)
+                            log('fixMobiPlayUrlJson', i)
+                            log('fixMobiPlayUrlJson_str', JSON.stringify(i))
+                            return i
+                        }
                         return result;
                     }
                     return result.result

--- a/packages/unblock-area-limit/src/main.js
+++ b/packages/unblock-area-limit/src/main.js
@@ -872,8 +872,7 @@ function scriptContent() {
                     // 在APP限定情况启用 mobi api 解析
                     if (window.__balh_app_only__) {
                         if (result['type'] == "DASH") {
-                            let i = fixMobiPlayUrlJson(result)
-                            return i
+                            return fixMobiPlayUrlJson(result)
                         }
                         return result;
                     }

--- a/packages/unblock-area-limit/src/main.js
+++ b/packages/unblock-area-limit/src/main.js
@@ -873,8 +873,6 @@ function scriptContent() {
                     if (window.__balh_app_only__) {
                         if (result['type'] == "DASH") {
                             let i = fixMobiPlayUrlJson(result)
-                            log('fixMobiPlayUrlJson', i)
-                            log('fixMobiPlayUrlJson_str', JSON.stringify(i))
                             return i
                         }
                         return result;

--- a/scripts/bilibili_bangumi_area_limit_hack.user.js
+++ b/scripts/bilibili_bangumi_area_limit_hack.user.js
@@ -3331,8 +3331,7 @@ function scriptSource(invokeBy) {
                         // 在APP限定情况启用 mobi api 解析
                         if (window.__balh_app_only__) {
                             if (result['type'] == "DASH") {
-                                let i = fixMobiPlayUrlJson(result);
-                                return i
+                                return fixMobiPlayUrlJson(result)
                             }
                             return result;
                         }

--- a/scripts/bilibili_bangumi_area_limit_hack.user.js
+++ b/scripts/bilibili_bangumi_area_limit_hack.user.js
@@ -820,7 +820,7 @@ function scriptSource(invokeBy) {
         theRequest.platform = 'android_b';
         theRequest.track_path = '0';
         theRequest.device = 'android';
-        // theRequest.fnval = '0'; // 强制 FLV
+        theRequest.fnval = '0'; // 强制 FLV
         theRequest.ts = `${~~(Date.now() / 1000)}`;
         // 所需参数数组
         let param_wanted = ['access_key', 'appkey', 'build', 'buvid', 'cid', 'device', 'ep_id', 'fnval', 'fnver', 'force_host', 'fourk', 'mobi_app', 'platform', 'qn', 'track_path', 'ts'];


### PR DESCRIPTION
关键数据在于 ```codecs``` 和 ```SegmentBase``` ，```SegmentBase``` 用于定义音视频流 sidx 的位置，B站播放器读取 sidx 来获取切片信息。

```codecs``` 基本上是固定的，而 ```SegmentBase``` 不是，对于APP限定番目前也没有发现有其他接口有这个数据，只能当场解析音视频流（下载前 6000 字节数据解析 sidx 位置），因此启动速度会比 flv 慢，因此目前还是使用的 FLV 播放，但是为 [泰区解锁](https://github.com/ipcjs/bilibili-helper/issues/722#issuecomment-762085869) 提供了前提条件。

解析 sidx 慢的一大原因是一个一个同步解析，如果大佬知道怎么做异步并发解析的话应该会快很多（比如并发解析生成一个 segmentBaseMap 供后续使用）。

PS：```main.dev.user.js``` 加上了授权的链接

PS：启用 DASH 就是注释 ```biliplus.ts``` 65 行的 ```theRequest.fnval = '0'; // 强制 FLV```

相关讨论：#711


![image](https://user-images.githubusercontent.com/24269465/105934250-cb730c00-608a-11eb-9eb6-bb85aad4f7cb.png)
