### PR TITLE
season数据优先使用 bangumi 接口，支持渲染泰区番剧播放页

### DIFF
--- a/packages/unblock-area-limit/src/api/bilibili.ts
+++ b/packages/unblock-area-limit/src/api/bilibili.ts
@@ -36,6 +36,36 @@ interface SeasonInfo {
     }
 }
 
+interface SeasonInfoOnBangumi {
+    code: number
+    result: {
+        season_id: number
+        season_title: string   // 季度标题，如 “TV” “第一季”
+        media_id: number
+        episodes: [{
+            aid: number
+            bvid: string
+            cid: number
+            ep_id: number
+            index: string  // 集数/简短名，显示在缩略集数
+            index_title: string  // 分集标题，泰区番剧通常为空
+            episode_status: number
+            episode_type: number
+            titleFormat?: string
+            loaded?: boolean
+            epStatus?: number
+            sectionType?: number
+            i?: number
+            id?: number
+            link?: string
+            title?: string
+        }]
+        evaluate: string  // 简介
+        cover: string
+        title: string  // 番剧名
+    }
+}
+
 export class BiliBiliApi {
     private server: string
     constructor(server: string = '//api.bilibili.com') {
@@ -47,5 +77,8 @@ export class BiliBiliApi {
     }
     getSeasonInfo(season_id: string | number) {
         return Async.ajax<SeasonInfo>(`${this.server}/pgc/view/web/season?season_id=${season_id}`)
+    }
+    getSeasonInfoByEpIdOnBangumi(ep_id: string | number) {
+        return Async.ajax<SeasonInfoOnBangumi>(`//bangumi.bilibili.com/view/web_api/season?ep_id=${ep_id}`)
     }
 }

--- a/packages/unblock-area-limit/src/feature/bili/area_limit_for_vue.ts
+++ b/packages/unblock-area-limit/src/feature/bili/area_limit_for_vue.ts
@@ -176,10 +176,11 @@ function fixBangumiPlayPage() {
                         let pvCounter = 1
                         const ep_length = result.result.episodes.length
                         const eps = JSON.stringify(result.result.episodes.map((item) => {
-                            item.titleFormat = "第" + item.index + "话 " + item.index_title
                             if (/^\d+$/.exec(item.index)) {
+                                item.titleFormat = "第" + item.index + "话 " + item.index_title
                                 item.i = +item.index - 1
                             } else {
+                                item.titleFormat = item.index
                                 item.i = ep_length - pvCounter
                                 pvCounter++
                                 item.index_title = item.index

--- a/packages/unblock-area-limit/src/feature/bili/area_limit_for_vue.ts
+++ b/packages/unblock-area-limit/src/feature/bili/area_limit_for_vue.ts
@@ -127,52 +127,50 @@ function fixBangumiPlayPage() {
                     // 不限制地区的接口，可以查询泰区番剧，该方法前置给代理服务器和BP节省点请求
                     // 如果该接口失效，自动尝试后面的方法
                     try {
-                        if (!templateArgs) {
-                            const result = await bilibiliApi.getSeasonInfoByEpIdOnBangumi(ep_id)
-                            if (result.code) {
-                                throw result
-                            }
-                            const ep = result.result.episodes.find(ep => ep.ep_id === +ep_id)
-                            if (!ep) {
-                                throw `通过bangumi接口未找到${ep_id}对应的视频信息`
-                            }
-                            const eps = JSON.stringify(result.result.episodes.map((item, index) => {
-                                // 返回的数据是有序的，不需要另外排序                                
-                                if (/^\d+$/.exec(item.index)) {
-                                    item.titleFormat = "第" + item.index + "话 " + item.index_title
-                                } else {
-                                    item.titleFormat = item.index
-                                    item.index_title = item.index
-                                }
-                                item.loaded = true
-                                item.epStatus = item.episode_status
-                                item.sectionType = 0
-                                item.id = +item.ep_id
-                                item.i = index
-                                item.link = 'https://www.bilibili.com/bangumi/play/ep' + item.ep_id
-                                item.title = item.index
-                                return item
-                            }))
-                            let titleForma
-                            if (ep.index_title) {
-                                titleForma = ep.index_title
+                        const result = await bilibiliApi.getSeasonInfoByEpIdOnBangumi(ep_id)
+                        if (result.code) {
+                            throw result
+                        }
+                        const ep = result.result.episodes.find(ep => ep.ep_id === +ep_id)
+                        if (!ep) {
+                            throw `通过bangumi接口未找到${ep_id}对应的视频信息`
+                        }
+                        const eps = JSON.stringify(result.result.episodes.map((item, index) => {
+                            // 返回的数据是有序的，不需要另外排序                                
+                            if (/^\d+$/.exec(item.index)) {
+                                item.titleFormat = "第" + item.index + "话 " + item.index_title
                             } else {
-                                titleForma = "第" + ep.index + "话"
+                                item.titleFormat = item.index
+                                item.index_title = item.index
                             }
-                            templateArgs = {
-                                id: ep.ep_id,
-                                aid: ep.aid,
-                                cid: ep.cid,
-                                bvid: ep.bvid,
-                                title: ep.index,
-                                titleFormat: titleForma,
-                                htmlTitle: result.result.title,
-                                mediaInfoId: result.result.media_id,
-                                mediaInfoTitle: result.result.title,
-                                evaluate: result.result.evaluate.replace(/\r\n/g, '').replace(/\n/g, ''),
-                                cover: result.result.cover,
-                                episodes: eps
-                            }
+                            item.loaded = true
+                            item.epStatus = item.episode_status
+                            item.sectionType = 0
+                            item.id = +item.ep_id
+                            item.i = index
+                            item.link = 'https://www.bilibili.com/bangumi/play/ep' + item.ep_id
+                            item.title = item.index
+                            return item
+                        }))
+                        let titleForma
+                        if (ep.index_title) {
+                            titleForma = ep.index_title
+                        } else {
+                            titleForma = "第" + ep.index + "话"
+                        }
+                        templateArgs = {
+                            id: ep.ep_id,
+                            aid: ep.aid,
+                            cid: ep.cid,
+                            bvid: ep.bvid,
+                            title: ep.index,
+                            titleFormat: titleForma,
+                            htmlTitle: result.result.title,
+                            mediaInfoId: result.result.media_id,
+                            mediaInfoTitle: result.result.title,
+                            evaluate: result.result.evaluate.replace(/\r\n/g, '').replace(/\n/g, ''),
+                            cover: result.result.cover,
+                            episodes: eps
                         }
                     } catch (e) {
                         util_warn('通过bangumi接口获取ep信息失败', e)

--- a/scripts/bilibili_bangumi_area_limit_hack.user.js
+++ b/scripts/bilibili_bangumi_area_limit_hack.user.js
@@ -786,6 +786,9 @@ function scriptSource(invokeBy) {
         getSeasonInfo(season_id) {
             return Async.ajax(`${this.server}/pgc/view/web/season?season_id=${season_id}`);
         }
+        getSeasonInfoByEpIdOnBangumi(ep_id) {
+            return Async.ajax(`//bangumi.bilibili.com/view/web_api/season?ep_id=${ep_id}`);
+        }
     }
 
     /**
@@ -1824,9 +1827,65 @@ function scriptSource(invokeBy) {
                         // 读取保存的season_id
                         const season_id = cookieStorage.get('balh_curr_season_id');
                         const ep_id = (window.location.pathname.match(/\/bangumi\/play\/ep(\d+)/) || ['', ''])[1];
+                        const bilibiliApi = new BiliBiliApi(balh_config.server_bilibili_api_proxy);
                         let templateArgs = null;
-                        if (balh_config.server_bilibili_api_proxy) {
-                            const bilibiliApi = new BiliBiliApi(balh_config.server_bilibili_api_proxy);
+                        // 不限制地区的接口，可以查询泰区番剧，该方法前置给代理服务器和BP节省点请求
+                        // 如果该接口失效，自动尝试后面的方法
+                        try {
+                            if (!templateArgs) {
+                                const result = yield bilibiliApi.getSeasonInfoByEpIdOnBangumi(ep_id);
+                                if (result.code) {
+                                    throw result;
+                                }
+                                const ep = result.result.episodes.find(ep => ep.ep_id === +ep_id);
+                                if (!ep) {
+                                    throw `通过bangumi接口未找到${ep_id}对应的视频信息`;
+                                }
+                                const eps = JSON.stringify(result.result.episodes.map((item, index) => {
+                                    // 返回的数据是有序的，不需要另外排序                                
+                                    if (/^\d+$/.exec(item.index)) {
+                                        item.titleFormat = "第" + item.index + "话 " + item.index_title;
+                                    }
+                                    else {
+                                        item.titleFormat = item.index;
+                                        item.index_title = item.index;
+                                    }
+                                    item.loaded = true;
+                                    item.epStatus = item.episode_status;
+                                    item.sectionType = 0;
+                                    item.id = +item.ep_id;
+                                    item.i = index;
+                                    item.link = 'https://www.bilibili.com/bangumi/play/ep' + item.ep_id;
+                                    item.title = item.index;
+                                    return item;
+                                }));
+                                let titleForma;
+                                if (ep.index_title) {
+                                    titleForma = ep.index_title;
+                                }
+                                else {
+                                    titleForma = "第" + ep.index + "话";
+                                }
+                                templateArgs = {
+                                    id: ep.ep_id,
+                                    aid: ep.aid,
+                                    cid: ep.cid,
+                                    bvid: ep.bvid,
+                                    title: ep.index,
+                                    titleFormat: titleForma,
+                                    htmlTitle: result.result.title,
+                                    mediaInfoId: result.result.media_id,
+                                    mediaInfoTitle: result.result.title,
+                                    evaluate: result.result.evaluate.replace(/\r\n/g, '').replace(/\n/g, ''),
+                                    cover: result.result.cover,
+                                    episodes: eps
+                                };
+                            }
+                        }
+                        catch (e) {
+                            util_warn('通过bangumi接口获取ep信息失败', e);
+                        }
+                        if (balh_config.server_bilibili_api_proxy && !templateArgs) {
                             try {
                                 const result = yield bilibiliApi.getSeasonInfoByEpId(ep_id);
                                 if (result.code) {
@@ -1895,7 +1954,7 @@ function scriptSource(invokeBy) {
                                 item.badge = '';
                                 item.badge_info = { "bg_color": "#FB7299", "bg_color_night": "#BB5B76", "text": "" };
                                 item.badge_type = 0;
-                                item.title = item.index.toString();
+                                item.title = item.index;
                                 item.id = +item.episode_id;
                                 item.cid = +item.danmaku;
                                 item.aid = +item.av_id;
@@ -1905,7 +1964,7 @@ function scriptSource(invokeBy) {
                                 item.rights = { 'allow_demand': 0, 'allow_dm': 1, 'allow_download': 0, 'area_limit': 0 };
                                 return item;
                             }).sort((a, b) => {
-                                return a.i - b.i;
+                                return a.i - b.i; // BP接口返回的数据是无序的，需要排序
                             }));
                             templateArgs = {
                                 id: ep.episode_id,

--- a/scripts/bilibili_bangumi_area_limit_hack.user.js
+++ b/scripts/bilibili_bangumi_area_limit_hack.user.js
@@ -1880,11 +1880,12 @@ function scriptSource(invokeBy) {
                             let pvCounter = 1;
                             const ep_length = result.result.episodes.length;
                             const eps = JSON.stringify(result.result.episodes.map((item) => {
-                                item.titleFormat = "第" + item.index + "话 " + item.index_title;
                                 if (/^\d+$/.exec(item.index)) {
+                                    item.titleFormat = "第" + item.index + "话 " + item.index_title;
                                     item.i = +item.index - 1;
                                 }
                                 else {
+                                    item.titleFormat = item.index;
                                     item.i = ep_length - pvCounter;
                                     pvCounter++;
                                     item.index_title = item.index;


### PR DESCRIPTION
泰区支持进度 +1，顺便能节约对代理服务器和 BiliPlus 的请求

![@KNCJ5)_}0`NVZK1H9M%J63](https://user-images.githubusercontent.com/24269465/106437087-d88b6300-64af-11eb-84c0-19c25306a0ff.png)
