### PR TITLE
添加泰区番剧支持

### DIFF
--- a/packages/unblock-area-limit/src/feature/bili/settings.ts
+++ b/packages/unblock-area-limit/src/feature/bili/settings.ts
@@ -303,7 +303,7 @@ export function settings() {
                     _('label', { style: { flex: '1 1 50%' } }, [
                         _('text', `泰国/东南亚: `),
                         _('input', {
-                            type: 'text', name: 'balh_server_custom_th', placeholder: '开发中……', disabled: 'true', event: {
+                            type: 'text', name: 'balh_server_custom_th', placeholder: '形如：https://hd.pilipili.com', event: {
                                 input: (event: Event) => {
                                     customTHServerCheckText.innerText = r.regex.bilibili_api_proxy.test((event.target as any).value.trim()) ? '✔️' : '🔗️'
                                     onSettingsFormChange(event)

--- a/packages/unblock-area-limit/src/main.user.js
+++ b/packages/unblock-area-limit/src/main.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         解除B站区域限制
 // @namespace    http://tampermonkey.net/
-// @version      8.1.4
+// @version      8.1.5
 // @description  通过替换获取视频地址接口的方式, 实现解除B站区域限制; 只对HTML5播放器生效;
 // @author       ipcjs
 // @supportURL   https://github.com/ipcjs/bilibili-helper/blob/user.js/packages/unblock-area-limit/README.md

--- a/scripts/bilibili_bangumi_area_limit_hack.user.js
+++ b/scripts/bilibili_bangumi_area_limit_hack.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         解除B站区域限制
 // @namespace    http://tampermonkey.net/
-// @version      8.1.4
+// @version      8.1.5
 // @description  通过替换获取视频地址接口的方式, 实现解除B站区域限制; 只对HTML5播放器生效;
 // @author       ipcjs
 // @supportURL   https://github.com/ipcjs/bilibili-helper/blob/user.js/packages/unblock-area-limit/README.md


### PR DESCRIPTION
#722 可以 close 了

另外泰区搜索的油猴有人写了，有空的话可以去整合一下（和owner打过招呼了） https://github.com/gamekingv/bilibili-oversea-search/blob/main/bilibili-oversea-search.user.js

PS：好气呀，昨天传主站 key 还能拿 720P 的，今天准备 PR 发现给降成 480P 了，怕是还要整泰区 access key （但是吧，很多泰区的国区弹幕和评论池子都关了，那泰区池子很多泰文也不是很舒服，加上泰区的会员要另外买，兴趣大减 emmm）

PS2：access key 替换这个可以交给解析服务器来做（实际上已经有实现了），脚本这边不做也行。


![_VPZU)P1`R9QF)MJ}IAFVIT](https://user-images.githubusercontent.com/24269465/107107451-fcfa8d00-686b-11eb-85ab-d0ac1ea8fb16.png)
