### PR TITLE
为泰区(东南亚) season 接口添加 access_key 参数

### DIFF
--- a/packages/unblock-area-limit/src/api/bilibili.ts
+++ b/packages/unblock-area-limit/src/api/bilibili.ts
@@ -132,6 +132,6 @@ export class BiliBiliApi {
         return Async.ajax<SeasonInfoOnBangumi>('//bangumi.bilibili.com/view/web_api/season?' + (ep_id != '' ? `ep_id=${ep_id}` : `season_id=${season_id}`))
     }
     getSeasonInfoByEpSsIdOnThailand(ep_id: string, season_id: string) {
-        return Async.ajax<SeasonInfoOnThailand>(`${this.server}/intl/gateway/v2/ogv/view/app/season?` + (ep_id != '' ? `ep_id=${ep_id}` : `season_id=${season_id}`) + '&mobi_app=bstar_a&s_locale=zh_SG')
+        return Async.ajax<SeasonInfoOnThailand>(`${this.server}/intl/gateway/v2/ogv/view/app/season?` + (ep_id != '' ? `ep_id=${ep_id}` : `season_id=${season_id}`) + `&mobi_app=bstar_a&s_locale=zh_SG${access_key_param_if_exist()}`)
     }
 }

--- a/packages/unblock-area-limit/src/api/bilibili.ts
+++ b/packages/unblock-area-limit/src/api/bilibili.ts
@@ -1,5 +1,6 @@
 import { balh_config } from "../feature/config"
 import { Async } from "../util/async"
+import { generateMobiPlayUrlParams } from "./biliplus"
 
 export const access_key_param_if_exist = function (isKghost = false) {
     // access_key是由B站验证的, B站帐号和BP帐号不同时, access_key无效
@@ -132,6 +133,8 @@ export class BiliBiliApi {
         return Async.ajax<SeasonInfoOnBangumi>('//bangumi.bilibili.com/view/web_api/season?' + (ep_id != '' ? `ep_id=${ep_id}` : `season_id=${season_id}`))
     }
     getSeasonInfoByEpSsIdOnThailand(ep_id: string, season_id: string) {
-        return Async.ajax<SeasonInfoOnThailand>(`${this.server}/intl/gateway/v2/ogv/view/app/season?` + (ep_id != '' ? `ep_id=${ep_id}` : `season_id=${season_id}`) + `&mobi_app=bstar_a&s_locale=zh_SG${access_key_param_if_exist()}`)
+        const params = '?' + (ep_id != '' ? `ep_id=${ep_id}` : `season_id=${season_id}`) + `&mobi_app=bstar_a&s_locale=zh_SG`
+        const newParams = generateMobiPlayUrlParams(params, true)
+        return Async.ajax<SeasonInfoOnThailand>(`${this.server}/intl/gateway/v2/ogv/view/app/season?` + newParams)
     }
 }

--- a/packages/unblock-area-limit/src/api/biliplus.ts
+++ b/packages/unblock-area-limit/src/api/biliplus.ts
@@ -76,7 +76,7 @@ export function generateMobiPlayUrlParams(originUrl: String, thailand = false) {
     theRequest.force_host = '2';  // 强制音视频返回 https
     theRequest.ts = `${~~(Date.now() / 1000)}`;
     // 所需参数数组
-    let param_wanted = ['area', 'access_key', 'appkey', 'build', 'buvid', 'cid', 'device', 'ep_id', 'fnval', 'fnver', 'force_host', 'fourk', 'mobi_app', 'platform', 'qn', 'track_path', 'ts'];
+    let param_wanted = ['area', 'access_key', 'appkey', 'build', 'buvid', 'cid', 'device', 'ep_id', 'fnval', 'fnver', 'force_host', 'fourk', 'mobi_app', 'platform', 'qn', 's_locale', 'season_id', 'track_path', 'ts'];
     // 生成 mobi api 参数字符串
     let mobi_api_params = '';
     for (let i = 0; i < param_wanted.length; i++) {


### PR DESCRIPTION
因为东南亚解析服务器请求多了会风控，所以多个公共解析服务器为了防止被滥用，必须传入 access_key 才能请求了