### PR TITLE
balh: 修复部分新番 web 锁区

### DIFF
--- a/packages/unblock-area-limit/src/api/bilibili.ts
+++ b/packages/unblock-area-limit/src/api/bilibili.ts
@@ -65,6 +65,9 @@ export interface SeasonInfoOnBangumi {
         cover: string
         title: string  // 番剧名
         total_ep: number
+        up_info: {
+            mid: number
+        }
     }
 }
 

--- a/packages/unblock-area-limit/src/api/bilibili.ts
+++ b/packages/unblock-area-limit/src/api/bilibili.ts
@@ -134,7 +134,7 @@ export class BiliBiliApi {
     }
     getSeasonInfoByEpSsIdOnThailand(ep_id: string, season_id: string) {
         const params = '?' + (ep_id != '' ? `ep_id=${ep_id}` : `season_id=${season_id}`) + `&mobi_app=bstar_a&s_locale=zh_SG`
-        const newParams = generateMobiPlayUrlParams(params, true)
+        const newParams = generateMobiPlayUrlParams(params, 'th')
         return Async.ajax<SeasonInfoOnThailand>(`${this.server}/intl/gateway/v2/ogv/view/app/season?` + newParams)
     }
 }

--- a/packages/unblock-area-limit/src/api/biliplus.ts
+++ b/packages/unblock-area-limit/src/api/biliplus.ts
@@ -35,16 +35,16 @@ function convertPlayUrl(originUrl: string) {
  * 
  * 参考：https://github.com/kghost/bilibili-area-limit/issues/16
  */
-export function getMobiPlayUrl(originUrl: String, host: String, thailand = false) {
+export function getMobiPlayUrl(originUrl: String, host: String, area: string) {
     // 合成泰区 url
-    if (thailand) {
-        return `${host}/intl/gateway/v2/ogv/playurl?${generateMobiPlayUrlParams(originUrl, true)}`
+    if (area == 'th') {
+        return `${host}/intl/gateway/v2/ogv/playurl?${generateMobiPlayUrlParams(originUrl, area)}`
     }
     // 合成完整 mobi api url
-    return `${host}/pgc/player/api/playurl?${generateMobiPlayUrlParams(originUrl)}`
+    return `${host}/pgc/player/api/playurl?${generateMobiPlayUrlParams(originUrl, area)}`
 }
 
-export function generateMobiPlayUrlParams(originUrl: String, thailand = false) {
+export function generateMobiPlayUrlParams(originUrl: String, area: string) {
     // 提取参数为数组
     let a = originUrl.split('?')[1].split('&');
     // 参数数组转换为对象
@@ -57,13 +57,14 @@ export function generateMobiPlayUrlParams(originUrl: String, thailand = false) {
     }
     // 追加 mobi api 需要的参数
     theRequest.access_key = localStorage.access_key;
-    if (thailand) {
+    if (area === 'th') {
         theRequest.area = 'th';
         theRequest.appkey = '7d089525d3611b1c';
         theRequest.build = '1001310';
         theRequest.mobi_app = 'bstar_a';
         theRequest.platform = 'android';
     } else {
+        theRequest.area = area;
         theRequest.appkey = '07da50c9a0bf829f';
         theRequest.build = '5380700';
         theRequest.device = 'android';
@@ -86,7 +87,7 @@ export function generateMobiPlayUrlParams(originUrl: String, thailand = false) {
     }
     // 准备明文
     let plaintext = ''
-    if (thailand) {
+    if (area === 'th') {
         plaintext = mobi_api_params.slice(0, -1) + `acd495b248ec528c2eed1e862d393126`;
     } else {
         plaintext = mobi_api_params.slice(0, -1) + `25bdede4e1581c836cab73a48790ca6e`;

--- a/packages/unblock-area-limit/src/feature/bili/area_limit_for_vue.ts
+++ b/packages/unblock-area-limit/src/feature/bili/area_limit_for_vue.ts
@@ -157,7 +157,7 @@ function fixBangumiPlayPage() {
         if (util_page.anime_ep() || util_page.anime_ss()) {
             const $app = document.getElementById('app')
             if (!$app || invalidInitialState) {
-                const appOnly = invalidInitialState?.mediaInfo?.rights?.appOnly ?? true
+                var appOnly = invalidInitialState?.mediaInfo?.rights?.appOnly ?? true
                 try {
                     // 读取保存的season_id
                     const season_id = (window.location.pathname.match(/\/bangumi\/play\/ss(\d+)/) || ['', cookieStorage.get('balh_curr_season_id')])[1]
@@ -169,8 +169,11 @@ function fixBangumiPlayPage() {
                     // 如果该接口失效，自动尝试后面的方法
                     try {
                         let result = await bilibiliApi.getSeasonInfoByEpSsIdOnBangumi(ep_id, season_id)
-                        if (balh_config.server_custom_th && result.code == -404) {
+                        if (balh_config.server_custom_th && (result.code == -404 || result.result.up_info.mid == 677043260 /* 主站残留泰区数据，部分不完整 */ )) {
                             result = await fixThailandSeason(ep_id, season_id)
+                        } else {
+                            // web 锁区别用 app api
+                            appOnly = false
                         }
                         if (result.code) {
                             throw result

--- a/packages/unblock-area-limit/src/feature/bili/area_limit_for_vue.ts
+++ b/packages/unblock-area-limit/src/feature/bili/area_limit_for_vue.ts
@@ -169,7 +169,7 @@ function fixBangumiPlayPage() {
                     // 如果该接口失效，自动尝试后面的方法
                     try {
                         let result = await bilibiliApi.getSeasonInfoByEpSsIdOnBangumi(ep_id, season_id)
-                        if (balh_config.server_custom_th && (result.code == -404 || result.result.total_ep == -1)) {
+                        if (balh_config.server_custom_th && result.code == -404) {
                             result = await fixThailandSeason(ep_id, season_id)
                         }
                         if (result.code) {

--- a/packages/unblock-area-limit/src/main.js
+++ b/packages/unblock-area-limit/src/main.js
@@ -907,7 +907,7 @@ function scriptContent() {
                     // 对应this.transToProxyUrl的参数, 用`/`分隔, 形如: `${proxyHost}/${area}`
                     let tried_server_args = []
                     const isTriedServerArg = (proxyHost, area) => tried_server_args.includes(`${proxyHost}/*`) || tried_server_args.includes(`${proxyHost}/${area}`)
-                    const requestPlayUrl = (proxyHost, area = '') => {
+                    const requestPlayUrl = (proxyHost, area) => {
                         tried_server_args.push(`${proxyHost}/${area}`)
                         return Async.ajax(this.transToProxyUrl(originUrl, proxyHost, area))
                             // 捕获错误, 防止依次尝试各各服务器的流程中止
@@ -996,15 +996,15 @@ function scriptContent() {
                     }
                     return Promise.resolve(result)  // 都失败了，返回最后一次数据
                 },
-                transToProxyUrl: function (originUrl, proxyHost, area = '') {
+                transToProxyUrl: function (originUrl, proxyHost, area) {
                     if (r.regex.bilibili_api_proxy.test(proxyHost)) {
                         if (area === 'th') {
                             // 泰区番剧解析
-                            return getMobiPlayUrl(originUrl, proxyHost, true)
+                            return getMobiPlayUrl(originUrl, proxyHost, area)
                         }
                         if (window.__balh_app_only__) {
                             // APP 限定用 mobi api
-                            return getMobiPlayUrl(originUrl, proxyHost)
+                            return getMobiPlayUrl(originUrl, proxyHost, area)
                         }
                         return originUrl.replace(/^(https:)?(\/\/api\.bilibili\.com\/)/, `$1${proxyHost}/`) + '&area=' + area + access_key_param_if_exist(true);
                     } else {


### PR DESCRIPTION
- 重建部分新番页面
  - https://www.bilibili.com/bangumi/media/md28235576
  - https://www.bilibili.com/bangumi/media/md28235296
- 尝试排除主站泰区残留 season，强制获取泰区 season（部分番剧集数不完整）
- 优化一些代码

如果确定没有 仅限app 观看的番剧，可以考虑移除掉了（我记忆中的仅限app番剧都转到泰区了）

close https://github.com/ipcjs/bilibili-helper/issues/900