### PR TITLE
balh: Fix subtitle cache

### DIFF
--- a/packages/unblock-area-limit/src/main.js
+++ b/packages/unblock-area-limit/src/main.js
@@ -161,11 +161,13 @@ function scriptContent() {
                                                     let origSubUrl = 'http:' + origSub.subtitle_url;
                                                     let origSubId = origSub.id;
                                                     let origSubRealId = BigInt(origSub.id_str);
+                                                    let encSubUrl = encodeURIComponent(origSubUrl);
+                                                    let encSubId = encodeURIComponent(origSub.id_str);
                                                     let targetSub = {
                                                         lan: target,
                                                         lan_doc: targetDoc,
                                                         is_lock: false,
-                                                        subtitle_url: `//www.kofua.top/bsub/${converter}?sub_url=${encodeURIComponent(origSubUrl)}`,
+                                                        subtitle_url: `//www.kofua.top/bsub/${converter}?sub_url=${encSubUrl}&sub_id=${encSubId}`,
                                                         type: 0,
                                                         id: origSubId + 1,
                                                         id_str: (origSubRealId + 1n).toString(),


### PR DESCRIPTION
直接用地址作为缓存键有问题，貌似由于cdn的关系，地址每天会变，
缓存不能长久。所以目前使用字幕id作为缓存键解决此问题。

如果能尽快合并发版最好，以减小繁化姬的压力。